### PR TITLE
Added support for webhook for GoodSign Api

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,14 +2,12 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug Netlify Functions",
+      "name": "Debug Netlify Functions (Linux)",
       "type": "node",
       "request": "launch",
-      "runtimeExecutable": "npx",
-      "runtimeArgs": ["netlify", "dev", "--port", "4225"],
-      "env": {
-        "NODE_OPTIONS": "--inspect=9229"
-      },
+      "runtimeExecutable": "/home/ak47/.nvm/versions/node/v25.5.0/bin/node",
+      "program": "/home/ak47/.nvm/versions/node/v25.5.0/lib/node_modules/netlify-cli/bin/run",
+      "args": ["dev", "--port", "4225"],
       "console": "integratedTerminal",
       "skipFiles": ["<node_internals>/**"]
     }

--- a/netlify/functions/0014_create_esign_workspace.js
+++ b/netlify/functions/0014_create_esign_workspace.js
@@ -1,73 +1,73 @@
-/**
- * File : 0014_create_esign_workspace.js
- * This file is used to create workspace for each user.
- * Must have feature flags enabled for this feature.
- */
-import { Constants } from "./utils/constants";
-import {
-  EsignWorkspaceUrl,
-  populateCorsHeaders,
-  validateRequest,
-} from "./utils/utils";
+// /**
+//  * File : 0014_create_esign_workspace.js
+//  * This file is used to create workspace for each user.
+//  * Must have feature flags enabled for this feature.
+//  */
+// import { Constants } from "./utils/constants";
+// import {
+//   EsignWorkspaceUrl,
+//   populateCorsHeaders,
+//   validateRequest,
+// } from "./utils/utils";
 
-export const handler = async (event) => {
-  const isValidRequest = validateRequest(event.headers["x-api-key"]);
-  if (!isValidRequest) {
-    console.debug(Constants.MethodNotAuthorized);
-    return {
-      statusCode: 401,
-      headers: populateCorsHeaders(),
-      body: JSON.stringify({ error: Constants.MethodNotAuthorized }),
-    };
-  }
+// export const handler = async (event) => {
+//   const isValidRequest = validateRequest(event.headers["x-api-key"]);
+//   if (!isValidRequest) {
+//     console.debug(Constants.MethodNotAuthorized);
+//     return {
+//       statusCode: 401,
+//       headers: populateCorsHeaders(),
+//       body: JSON.stringify({ error: Constants.MethodNotAuthorized }),
+//     };
+//   }
 
-  if (("POST" || "OPTIONS") !== event.httpMethod) {
-    console.debug(Constants.MethodNotAllowed);
-    return {
-      statusCode: 405,
-      headers: populateCorsHeaders(),
-      body: JSON.stringify({ error: Constants.MethodNotAllowed }),
-    };
-  }
+//   if (("POST" || "OPTIONS") !== event.httpMethod) {
+//     console.debug(Constants.MethodNotAllowed);
+//     return {
+//       statusCode: 405,
+//       headers: populateCorsHeaders(),
+//       body: JSON.stringify({ error: Constants.MethodNotAllowed }),
+//     };
+//   }
 
-  try {
-    const AdminKey = process.env.ESIGN_ADMIN_KEY;
-    const { workspaceId } = JSON.parse(event.body);
+//   try {
+//     const AdminKey = process.env.ESIGN_ADMIN_KEY;
+//     const { workspaceId } = JSON.parse(event.body);
 
-    const response = await fetch(EsignWorkspaceUrl, {
-      method: "POST",
-      headers: {
-        Authorization: AdminKey,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        name: workspaceId,
-      }),
-    });
+//     const response = await fetch(EsignWorkspaceUrl, {
+//       method: "POST",
+//       headers: {
+//         Authorization: AdminKey,
+//         "Content-Type": "application/json",
+//       },
+//       body: JSON.stringify({
+//         name: workspaceId,
+//       }),
+//     });
 
-    if (!response.ok) {
-      console.debug(Constants.InvalidRequest);
-      return {
-        statusCode: 500,
-        body: JSON.stringify({ error: Constants.InvalidRequest }),
-      };
-    }
+//     if (!response.ok) {
+//       console.debug(Constants.InvalidRequest);
+//       return {
+//         statusCode: 500,
+//         body: JSON.stringify({ error: Constants.InvalidRequest }),
+//       };
+//     }
 
-    const workspace = await response.json();
-    return {
-      statusCode: 200,
-      body: JSON.stringify({
-        message: "Workspace created successfully",
-        workspaceId: workspace.id,
-        name: workspace.name,
-        createdAt: workspace.created_date,
-      }),
-    };
-  } catch (err) {
-    console.debug("failed to create esign workspace. details ", err);
-    return {
-      statusCode: 500,
-      body: JSON.stringify({ error: err.message }),
-    };
-  }
-};
+//     const workspace = await response.json();
+//     return {
+//       statusCode: 200,
+//       body: JSON.stringify({
+//         message: "Workspace created successfully",
+//         workspaceId: workspace.id,
+//         name: workspace.name,
+//         createdAt: workspace.created_date,
+//       }),
+//     };
+//   } catch (err) {
+//     console.debug("failed to create esign workspace. details ", err);
+//     return {
+//       statusCode: 500,
+//       body: JSON.stringify({ error: err.message }),
+//     };
+//   }
+// };

--- a/netlify/functions/0018_template_to_esign_document.js
+++ b/netlify/functions/0018_template_to_esign_document.js
@@ -10,11 +10,14 @@ import {
   DocumentThreePageSchema,
   DocumentTwoPageSchema,
   GoodSignTemplateToEsignUrl,
+  initializeFirebase,
   populateApiFields,
   populateCorsHeaders,
   populateSignerFields,
   validateRequest,
 } from "./utils/utils";
+
+const isDevEnv = process.env.DEV_ENV === "true";
 
 export const handler = async (event) => {
   const isValidRequest = validateRequest(event.headers["x-api-key"]);
@@ -37,11 +40,24 @@ export const handler = async (event) => {
 
   try {
     const EsignAdminKey = process.env.ESIGN_ADMIN_KEY;
-    const { uuid, doc_name, userId, additional_senders, fields } = JSON.parse(
-      event.body,
-    );
+    const {
+      uuid,
+      doc_name,
+      userId,
+      additional_senders,
+      propertyId,
+      primaryTenantId,
+      fields,
+    } = JSON.parse(event.body);
 
-    if (!userId || !uuid || !doc_name || Array.isArray(fields)) {
+    if (
+      !userId ||
+      !uuid ||
+      !doc_name ||
+      !propertyId ||
+      !primaryTenantId ||
+      Array.isArray(fields)
+    ) {
       console.debug(Constants.MissingRequiredFields);
       return {
         statusCode: 400,
@@ -70,8 +86,11 @@ export const handler = async (event) => {
       uuid: uuid,
       doc_name: doc_name,
       attachment_names_in_order: [],
-      metadata: ["placeholder"],
-      webhook: "", // TODO: netlify function that can handle a simple payload
+      metadata: [
+        { propertyId: propertyId },
+        { primaryTenantId: primaryTenantId },
+      ],
+      webhook: `${process.env.SITE_URL}/.netlify/functions/0020_fetch_goodsign_webhook`,
       cc_email: additional_senders,
       smsverify: false,
       send_in_order: false,
@@ -115,7 +134,22 @@ export const handler = async (event) => {
     }
 
     const signingRequestId = signingRequest?.doc?.uuid;
-    console.debug(Constants.EsignCreateSigingRequestMessage, signingRequestId);
+    const signingRequestStatus = signingRequest?.doc?.status;
+    console.debug(
+      Constants.EsignCreateSigingRequestMessage,
+      signingRequestId,
+      signingRequestStatus,
+    );
+
+    const esignDocumentRequest = {
+      signingRequestId,
+      signingRequestStatus,
+      propertyId,
+      userId,
+      primaryTenantId,
+    };
+
+    updateEsignDocumentStatus(esignDocumentRequest);
 
     return {
       statusCode: 200,
@@ -133,4 +167,28 @@ export const handler = async (event) => {
       body: JSON.stringify({ error: err.message }),
     };
   }
+};
+
+// updateEsignDocumentStatus ...
+// defines a function that peforms update after a document is requested to be signed
+const updateEsignDocumentStatus = async (req) => {
+  if (!req.signingRequestId || !req.propertyId) {
+    console.debug(Constants.MissingRequiredFields);
+    throw new Error(Constants.MissingRequiredFields);
+  }
+
+  const db = initializeFirebase(isDevEnv);
+  const createdDocumentsRef = doc(db, "createdDocuments", req.signingRequestId);
+  const updatedSigingRequestDetails = {
+    ...req,
+    signingRequestCreatedOn: dayjs(),
+  };
+
+  console.debug(Constants.ARPSUpdatedEsignRequest);
+  await setDoc(
+    createdDocumentsRef,
+    { updatedSigingRequestDetails },
+    { merge: true },
+  );
+  return;
 };

--- a/netlify/functions/0020_fetch_goodsign_webhook.js
+++ b/netlify/functions/0020_fetch_goodsign_webhook.js
@@ -1,0 +1,65 @@
+/**
+ * File : 0020_fetch_goodsign_webhook.js
+ *
+ * This file is used to fetch data from good sign when the event loop
+ * is completed in good sign for Esign purposes. This functionality is
+ * used by esign to support XX event after an activity in esign has been completed.
+ * Eg, if a document got signed, or is ready to be signed, then the webhook
+ * should be called by esign to mark the esign complete in the db.
+ *
+ * Must have feature flags enabled for this feature.
+ */
+import dayjs from "dayjs";
+
+import { Constants } from "./utils/constants";
+import { initializeFirebase } from "./utils/utils";
+
+const isDevEnv = process.env.DEV_ENV === "true";
+
+export const handler = async (event) => {
+  try {
+    const payload = JSON.parse(event.body);
+    if (!payload) {
+      console.debug(Constants.EsignMissingPayloadFromWebhookMessage);
+      return;
+    }
+
+    const { doc } = payload;
+    if (doc) {
+      console.debug(Constants.EsignWebhookReceivedMessage);
+      updateEsignDetails(doc);
+    }
+
+    return null;
+  } catch (err) {
+    console.debug(Constants.EsignWebhookErrorMessage, err);
+    return null;
+  }
+};
+
+// updateEsignDetails ...
+// defines a function that updates esign details
+const updateEsignDetails = async (esignDetails) => {
+  if (!esignDetails.uuid || !esignDetails.name || !esignDetails.status) {
+    console.debug(Constants.MissingRequiredFields);
+    throw new Error(Constants.MissingRequiredFields);
+  }
+
+  const db = initializeFirebase(isDevEnv);
+  const updatedDocumentRef = doc(db, "createdDocuments", esignDetails.uuid);
+  const updatedSigingRequestDetails = {
+    signingRequestId: esignDetails.uuid,
+    signingRequestStatus: esignDetails.status,
+    updatedOn: dayjs(),
+  };
+
+  console.debug(Constants.ARPSUpdatedEsignRequest);
+  await setDoc(
+    updatedDocumentRef,
+    { updatedSigingRequestDetails },
+    { merge: true },
+  );
+
+  console.debug("Successfully processed webhook message");
+  return;
+};

--- a/netlify/functions/utils/constants.js
+++ b/netlify/functions/utils/constants.js
@@ -21,19 +21,31 @@ export const Constants = {
     "Failed to update database with details from webhook handler",
   ARPSCreateSigningRequestInitializedMessage:
     "Attempting to create signing request",
+  ARPSUpdatedEsignRequest: "Updated esign request",
+
   EsignCreateSigingRequestMessage: "Esign signing request created",
   EsignParsingDataErrorMessage: "Error during parsing of signing request",
+  EsignWebhookReceivedMessage: "Received payload from Esign provider ",
+  EsignWebhookErrorMessage:
+    "Error during webhook response from Esign provider ",
+  EsignMissingPayloadFromWebhookMessage:
+    "Invalid webhook request. Missing payload from provided request",
+
   MethodNotAllowed: "Method not allowed",
   MethodNotAuthorized: "Method not authorized",
   MissingRequiredFields: "Missing required fields",
   MissingPaymentIntentFromStripe: "Invalid payment intent from stripe",
   MissingOrInvalidPaymentIntentFromStripe:
     "Missing payment intent or invalid payment intent status from stripe",
+
   PaymentRecievedYetToProcess:
     "Payment recieved, but has not been completed yet from stripe",
+
   StripePaymentStatusCompleted: "paid",
   StripePaymentStatusManualStatus: "manual",
   StripePaymentIntentStatusCompleted: "succeeded",
-  InvalidRequest: "Invalid request detected.",
+
+  InvalidRequest: "Invalid request detected",
+
   UnknownErrorOccured: "An error occured while processing this request",
 };

--- a/netlify/functions/utils/utils.js
+++ b/netlify/functions/utils/utils.js
@@ -279,7 +279,7 @@ export const populateCorsHeaders = () => {
 // validateRequest ...
 // defines a function that is used to validate a request
 export const validateRequest = (apiKey = "") => {
-  if (isDevEnv) return true;
+  if (isDevEnv === "true") return true;
   if (!isDevEnv && apiKey === IntegrationApiKey) return true;
   return false;
 };


### PR DESCRIPTION
Added ability to create and update webhook

Added the ability to create webhook once the esign document is created. Created a seperate table
to support this ask. The table should have a constraint to have only 1 unique property id, but this
might have to be done via composite key. Created ticket #257 for this.

Also updated the webhook for good sign api. This should now update the db with the provided status for the
selected document id. The status should be used in the UI as well so that the users are aware of the document status

Updated constants as well.

Closes https://github.com/earmuff-jam/homehive/issues/194