### PR TITLE
Removed unwanted checks for Admin in Test Env

### DIFF
--- a/netlify/functions/0012_update_stripe_payments.js
+++ b/netlify/functions/0012_update_stripe_payments.js
@@ -18,22 +18,9 @@ import {
 } from "./utils/utils";
 
 const isDevEnv = process.env.DEV_ENV === "true";
-const AdminAuthorizedKey = process.env.ADMIN_KEY;
 const IntegrationKey = process.env.INTEGRATION_KEY;
 
 export const handler = async (event) => {
-  if (!isDevEnv && event.queryStringParameters?.key !== AdminAuthorizedKey) {
-    console.debug(Constants.MethodNotAuthorized);
-    return {
-      statusCode: 401,
-      headers: {
-        ...populateCorsHeaders(),
-        "Content-Type": "application/json",
-      },
-      body: Constants.MethodNotAuthorized,
-    };
-  }
-
   try {
     // if the "createdBy" column exists, we assume that the webhook request
     // contained metadata which needs to be stored and processed differently.

--- a/netlify/functions/0024_update_user_subscription.js
+++ b/netlify/functions/0024_update_user_subscription.js
@@ -15,22 +15,9 @@ import {
 } from "./utils/utils";
 
 const isDevEnv = process.env.DEV_ENV === "true";
-const AdminAuthorizedKey = process.env.ADMIN_KEY;
 const IntegrationKey = process.env.INTEGRATION_KEY;
 
 export const handler = async (event) => {
-  if (!isDevEnv && event.queryStringParameters?.key !== AdminAuthorizedKey) {
-    console.debug(Constants.MethodNotAuthorized);
-    return {
-      statusCode: 401,
-      headers: {
-        ...populateCorsHeaders(),
-        "Content-Type": "application/json",
-      },
-      body: Constants.MethodNotAuthorized,
-    };
-  }
-
   try {
     const data = JSON.parse(event.body);
     // other values can be non-existent

--- a/netlify/functions/0028_AddressOnetimePayment.js
+++ b/netlify/functions/0028_AddressOnetimePayment.js
@@ -94,9 +94,10 @@ export const handler = async (event) => {
         },
       ],
       success_url:
-        process.env.STRIPE_PAYMENT_SUCCESS_URL +
+        process.env.BASE_SERVICE_URL +
+        "/rent/rental?success=1" +
         "&session_id={CHECKOUT_SESSION_ID}",
-      cancel_url: process.env.STRIPE_PAYMENT_FAILURE_URL,
+      cancel_url: process.env.BASE_SERVICE_URL + "/rent/rental?refresh=1",
       metadata: {
         customer_email: tenantEmail,
         tenantId,

--- a/netlify/functions/0031_ProcessEsignToken.js
+++ b/netlify/functions/0031_ProcessEsignToken.js
@@ -13,22 +13,9 @@ import { Constants } from "./utils/constants";
 import { initializeFirebase, populateCorsHeaders } from "./utils/utils";
 
 const isDevEnv = process.env.DEV_ENV === "true";
-const AdminAuthorizedKey = process.env.ADMIN_KEY;
 const IntegrationKey = process.env.INTEGRATION_KEY;
 
 export const handler = async (event) => {
-  if (!isDevEnv && event.queryStringParameters?.key !== AdminAuthorizedKey) {
-    console.debug(Constants.MethodNotAuthorized);
-    return {
-      statusCode: 401,
-      headers: {
-        ...populateCorsHeaders(),
-        "Content-Type": "application/json",
-      },
-      body: Constants.MethodNotAuthorized,
-    };
-  }
-
   try {
     const data = JSON.parse(event.body);
     console.debug(Constants.StripeETSSCollectionInit);

--- a/netlify/functions/utils/utils.js
+++ b/netlify/functions/utils/utils.js
@@ -313,7 +313,7 @@ export const generateOnetimePaymentChargeNotification = (cost, link) => {
   Please ensure that all information is valid and correct.
 
   One time cost: $${cost}
-  Payment Link: $${link}
+  Payment Link: ${link}
 
   Please note that some transaction take couple of days to process fully.
 


### PR DESCRIPTION
- Removed isAdminAuthorized check so that the webhook handlers can process the api correctly. This was copied from ARPS handler, which uses github to invoke api and trigger netlify functions which requires admin key in the query string param. We don't have that for webhook handlers, hence removing this code.

- Other minor cleanup and tech debt fixes